### PR TITLE
Make sure trusted-certs exists

### DIFF
--- a/oauth/.ddev/config.yaml
+++ b/oauth/.ddev/config.yaml
@@ -16,7 +16,6 @@ composer_version: "2"
 web_environment: []
 hooks:
     pre-start:
-        - exec-host: mkdir -p "${DDEV_APPROOT}/.ddev/gitlab/etc/gitlab/trusted-certs"
         - exec-host: cp "$(mkcert -CAROOT)"/rootCA.pem "${DDEV_APPROOT}/.ddev/gitlab/etc/gitlab/trusted-certs/rootCA.crt"
 
 # Key features of DDEV's config.yaml:

--- a/oauth/.ddev/gitlab/docker/Dockerfile
+++ b/oauth/.ddev/gitlab/docker/Dockerfile
@@ -1,4 +1,0 @@
-FROM gitlab/gitlab-ce:16.9.2-ce.0
-
-COPY * /usr/local/share/ca-certificates/
-RUN update-ca-certificates --fresh

--- a/oauth/.ddev/gitlab/etc/gitlab/trusted-certs/.gitmanaged
+++ b/oauth/.ddev/gitlab/etc/gitlab/trusted-certs/.gitmanaged
@@ -1,0 +1,1 @@
+The existence of this file will make sure the trusted-certs directory is created


### PR DESCRIPTION
* The trusted-certs directory can be pre-created by git and we won't have to worry about its permissions. We'll just add a .gitmanaged file to it (any file would work)
* Then we don't have to have an exec-host to create it
* Remove leftover Dockerfile.